### PR TITLE
Use corresponding allocate/free functions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Changes with IDN 0.1.1 (2021-06-09)
+
+* Use xfree() only with memory allocated with xmalloc()/xrealloc(). Free
+  IDN-allocated memory with idn_free()
+
 Changes with IDN 0.1.0 (2011-03-31)
 
 * Fix compilation errors in ruby 1.9.2p0 (2010-08-18 revision 29036).

--- a/ext/idna.c
+++ b/ext/idna.c
@@ -88,13 +88,13 @@ static VALUE toASCII(int argc, VALUE argv[], VALUE self)
   rc = idna_to_ascii_8z(RSTRING_PTR(str), &buf, flags);
 
   if (rc != IDNA_SUCCESS) {
-    xfree(buf);
+    idn_free(buf);
     rb_raise(eIdnaError, "%s (%d)", idna_strerror(rc), rc);
     return Qnil;
   }
 
   retv = rb_str_new2(buf);
-  xfree(buf);
+  idn_free(buf);
   return retv;
 }
 
@@ -128,13 +128,13 @@ static VALUE toUnicode(int argc, VALUE argv[], VALUE self)
   rc = idna_to_unicode_8z8z(RSTRING_PTR(str), &buf, flags);
 
   if (rc != IDNA_SUCCESS) {
-    xfree(buf);
+    idn_free(buf);
     rb_raise(eIdnaError, "%s (%d)", idna_strerror(rc), rc);
     return Qnil;
   }
 
   retv = rb_enc_str_new(buf, strlen(buf), rb_utf8_encoding());
-  xfree(buf);
+  idn_free(buf);
   return retv;
 }
 

--- a/ext/punycode.c
+++ b/ext/punycode.c
@@ -72,7 +72,7 @@ static VALUE encode(VALUE self, VALUE str)
     buf = realloc(buf, buflen);
 
     if (buf == NULL) {
-      xfree(ustr);
+      idn_free(ustr);
       rb_raise(rb_eNoMemError, "cannot allocate memory (%d bytes)", (uint32_t)buflen);
       return Qnil;
     }
@@ -84,7 +84,7 @@ static VALUE encode(VALUE self, VALUE str)
     } else if (rc == PUNYCODE_BIG_OUTPUT) {
       buflen += 0x100;
     } else {
-      xfree(ustr);
+      idn_free(ustr);
       xfree(buf);
       rb_raise(ePunycodeError, "%s (%d)", punycode_strerror(rc), rc);
       return Qnil;
@@ -92,7 +92,7 @@ static VALUE encode(VALUE self, VALUE str)
   }
 
   retv = rb_str_new(buf, buflen);
-  xfree(ustr);
+  idn_free(ustr);
   xfree(buf);
   return retv;
 }
@@ -136,7 +136,7 @@ static VALUE decode(VALUE self, VALUE str)
   buf = stringprep_ucs4_to_utf8(ustr, len, NULL, &len);
   retv = rb_enc_str_new(buf, len, rb_utf8_encoding());
   xfree(ustr);
-  xfree(buf);
+  idn_free(buf);
   return retv;
 }
 

--- a/ext/punycode.c
+++ b/ext/punycode.c
@@ -69,7 +69,7 @@ static VALUE encode(VALUE self, VALUE str)
   ustr = stringprep_utf8_to_ucs4(RSTRING_PTR(str), RSTRING_LEN(str), &len);
 
   while (1) {
-    buf = realloc(buf, buflen);
+    buf = xrealloc(buf, buflen);
 
     if (buf == NULL) {
       idn_free(ustr);
@@ -117,7 +117,7 @@ static VALUE decode(VALUE self, VALUE str)
   str = rb_check_convert_type(str, T_STRING, "String", "to_s");
 
   len = RSTRING_LEN(str);
-  ustr = malloc(len * sizeof(punycode_uint));
+  ustr = xmalloc(len * sizeof(punycode_uint));
 
   if (ustr == NULL) {
     rb_raise(rb_eNoMemError, "cannot allocate memory (%d bytes)", (uint32_t)len);

--- a/ext/stringprep.c
+++ b/ext/stringprep.c
@@ -72,7 +72,7 @@ static VALUE stringprep_internal(VALUE str, const char *profile)
   }
 
   retv = rb_str_new2(buf);
-  xfree(buf);
+  idn_free(buf);
   return retv;
 }
 
@@ -156,7 +156,7 @@ static VALUE nfkc_normalize(VALUE self, VALUE str)
   buf = stringprep_utf8_nfkc_normalize(RSTRING_PTR(str), RSTRING_LEN(str));
 
   retv = rb_str_new2(buf);
-  xfree(buf);
+  idn_free(buf);
   return retv;
 }
 

--- a/idn-ruby.gemspec
+++ b/idn-ruby.gemspec
@@ -5,11 +5,11 @@
 
 Gem::Specification.new do |s|
   s.name = %q{idn-ruby}
-  s.version = "0.1.0"
+  s.version = "0.1.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Erik Abele", "Bharanee Rathna"]
-  s.date = %q{2011-05-31}
+  s.date = %q{2021-06-09}
   s.description = %q{
     Ruby Bindings for the GNU LibIDN library, an implementation of the
     Stringprep, Punycode and IDNA specifications defined by the IETF


### PR DESCRIPTION
Ruby's `xfree()` is only safe to use with memory allocated by its `xmalloc()` family ([ref](https://github.com/ruby/ruby/blob/master/include/ruby/internal/xmalloc.h#L233-L254)). Use `xmalloc()` family for local allocations, and `idn_free` to free resources allocated by libidn.