### PR TITLE
Fixed segv in latest ruby-head when bad utf-8 give into Stringprep.nfkc_normalize

### DIFF
--- a/ext/stringprep.c
+++ b/ext/stringprep.c
@@ -155,7 +155,9 @@ static VALUE nfkc_normalize(VALUE self, VALUE str)
 
   str = rb_check_convert_type(str, T_STRING, "String", "to_s");
   buf = stringprep_utf8_nfkc_normalize(RSTRING_PTR(str), RSTRING_LEN(str));
-
+  if (buf == NULL) {
+    return Qnil;
+  }
   retv = rb_utf8_str_new_cstr(buf);
   idn_free(buf);
   return retv;

--- a/test/tc_Stringprep.rb
+++ b/test/tc_Stringprep.rb
@@ -48,7 +48,8 @@ class Test_Stringprep < Test::Unit::TestCase
 
   TESTCASES_NFKC = {
     'A' => [ "\xC2\xB5", "\xCE\xBC" ],
-    'B' => [ "\xC2\xAA", "\x61" ]
+    'B' => [ "\xC2\xAA", "\x61" ],
+    'C' => [ "\xE8", nil ]
   }
 
   def setup


### PR DESCRIPTION
Addressed to #9 