### PR TITLE
README: Use the correct gem name

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,20 +52,20 @@ Simply invoke the standard RubyGems commands (install, update, ...),
 for example:
 
 ```bash
-gem install --remote --test idn
+gem install --remote idn-ruby
 ```
 
 or if the GNU LibIDN library can only be found in a non-standard location
 
 ```bash
-gem install --remote --test idn -- \
+gem install --remote idn-ruby \
   --with-idn-dir=/path/to/non/standard/location
 ```
 
 or in an even more complex setup
 
 ```bash
-gem install --remote --test idn -- \
+gem install --remote idn-ruby -- \
   --with-idn-lib=/path/to/non/standard/location/lib \
   --with-idn-include=/path/to/non/standard/location/include
 ```


### PR DESCRIPTION
This gem is published at https://rubygems.org/gems/idn-ruby

Not sure what https://rubygems.org/gems/idn is.

Also remove the invalid flag `--test`:

    $ gem install --remote --test idn-ruby
    ERROR:  While executing gem ... (OptionParser::InvalidOption)
        invalid option: --test

    $ gem --version
    3.2.22