### PR TITLE
Support libidn installed with pkg-config support

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -21,6 +21,8 @@
 
 require 'mkmf'
 
+pkg_config 'libidn'
+
 @libs = ['idn']
 @headers = ['idna.h', 'punycode.h', 'stringprep.h']
 


### PR DESCRIPTION
If compilation / linking information is provided by pkg-config, then use the information.  Homebrew (and other package managers) will install pkg-config information, so we don't need to specify compilation info when installing the gem.

With this change I can just do `rake compile` on Apple Silicon without manually specifying the installation location of libidn